### PR TITLE
Update video embed styles

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -1281,13 +1281,22 @@ body > footer .nav-list.social {
   width: 100%;
   height: 0;
   padding-top: 56.25%;
-  margin-top: 30px;
+  margin: 30px 0;
 }
 .video-wrapper .video-embed {
   position: absolute;
   top: 0;
   left: 0;
   height: 100%;
+  width: 100%;
+}
+.native-video-wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin: 30px 0;
+}
+.native-video-wrapper .native-video-embed {
   width: 100%;
 }
 .hero {

--- a/src/components/video-embed.less
+++ b/src/components/video-embed.less
@@ -6,13 +6,25 @@
   width: 100%;
   height: 0; // no height, only padding to provide illusion of height
   padding-top: 56.25%; // 16 / 9 aspect
-  margin-top: @base-size;
+  margin: @base-size 0;
 
   .video-embed {
     position: absolute;
     top: 0;
     left: 0;
     height: 100%;
+    width: 100%;
+  }
+}
+
+// native video uses flex to center as won't know aspect ratio
+.native-video-wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin: @base-size 0;
+
+  .native-video-embed {
     width: 100%;
   }
 }


### PR DESCRIPTION
This adds styles to center native video sources where we may not know the aspect ratio. Also adds margin between the bottom of the video and the close button for both youtube and native video sources. Includes built `dist` css file.